### PR TITLE
fixed stack overflow when gridGap is at zero

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -24,6 +24,10 @@ function clamp(num, a, b) {
 }
 
 function getDensity(data) {
+    if (gridGap === 0)
+    {
+        return 1;
+    }
     const fontSize = 11;
     ctx.font = `${fontSize * data.pixelRatio}px Arial`;
     const rulerWidth = ctx.measureText('99:99:99').width;


### PR DESCRIPTION
from memory that's the change I did at the office.

It was creating an error when killing/creating the WF which prevented me from creating/killing it fast.

Not sure if I should return 1 or 0